### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,18 @@
-# GameBoy Bezels for RP5
+# Game Boy Bezels for RP5
 
-These are some bezels for Gameboy DMG, Pocket, Color, and Advanced I've make for RetroArch and tested on the Retroid Pocket 5. These are based on the style of [mugwomp93's overlays for 640x480 devices](https://github.com/mugwomp93/muOS_Customization). Russ from [RetroGameCorps has put together an excellent guide](https://retrogamecorps.com/2024/09/01/guide-shaders-and-overlays-on-retro-handhelds/) on how to use shaders and overlays on RetroArch to get overlays like these working.
+These are some bezels for Game Boy DMG, Pocket, Color, and Advance I've made for RetroArch, and tested on the Retroid Pocket 5. These are based on the style of [mugwomp93's overlays for 640x480 devices](https://github.com/mugwomp93/muOS_Customization). Russ from [Retro Game Corps has put together an excellent guide](https://retrogamecorps.com/2024/09/01/guide-shaders-and-overlays-on-retro-handhelds/) on how to use shaders and overlays in RetroArch to get overlays like these working.
 
-## Gameboy DMG
+## Game Boy DMG
 <img src="https://github.com/user-attachments/assets/774abebd-c846-4129-905a-6607172a8e84" alt="Gameboy DMG" width="500" height="281">
 <img src="https://github.com/user-attachments/assets/4ae8e4fc-bd9e-4cc9-af7e-3fa85b6fcf8e" alt="Gameboy DMG Black" width="500" height="281">
 
-## Gameboy Pocket
+## Game Boy Pocket
 <img src="https://github.com/user-attachments/assets/9c3b3b26-21cf-4cb6-8ab7-8df615e0ce1a" alt="Gameboy Pocket" width="500" height="281"> <img src="https://github.com/user-attachments/assets/7cd81bd7-7a44-48b1-9886-29a3aead19e6" alt="Gameboy Pocket Black" width="500" height="281">
 
-## Gameboy Color
+## Game Boy Color
 <img src="https://github.com/user-attachments/assets/8ef0258f-8220-423f-b58c-4d3235580652" alt="Gameboy Color" width="500" height="281"> <img src="https://github.com/user-attachments/assets/bbdc6502-4c47-4926-9863-18e9c7b6c661" alt="Gameboy Color Black" width="500" height="281">
 
-## Gameboy Advanced
+## Game Boy Advance
 
 <img src="https://github.com/user-attachments/assets/611cdaed-b02a-4285-ac99-5fd8044468b3" alt="GBA" width="500" height="281">
 <img src="https://github.com/user-attachments/assets/95ee3bb6-6956-48cd-8b42-253b93e80346" alt="GBA Black" width="500" height="281">


### PR DESCRIPTION
The official name is "Game Boy" as two separate words, and also it is the "Game Boy Advance" not the Advanced